### PR TITLE
v0.0.2

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,33 +1,23 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>3Pro 2024</title>
-    <link rel="stylesheet" href="styles.css" />
+    <title>Title</title>
+    <link rel="stylesheet" href="./title/style.css" />
   </head>
-
   <body>
-    <header>
-      <h1>Welcome to 3Pro 2024</h1>
-    </header>
-    <main>
-      <section id="introduction">
-        <h2>Introduction</h2>
-        <p>This is a sample HTML document for the 3Pro 2024 project.</p>
-      </section>
-      <section id="features">
-        <h2>Features</h2>
-        <ul>
-          <li><a href="./learn/index.html">ゲーム</a></li>
-          <li><a href="./quiz">クイズ</a></li>
-          <li><a href="./mission">クイズ</a></li>
-        </ul>
-      </section>
-    </main>
-    <footer>
-      <p>&copy; 2024 3Pro Project. All rights reserved.</p>
-    </footer>
-    <script src="script.js"></script>
+    <button class="btn" id="achieve" onclick="location.href='./achieve/'">
+      <img src="/trophy.png" width="30px" height="30px" />
+    </button>
+    <div id="title">手話ぷら</div>
+    <button class="btn" id="toQuiz" onclick="location.href='./modeselect/'">
+      クイズ
+    </button>
+    <button class="btn" id="toLearn" onclick="location.href='./learn/'">
+      学習
+    </button>
+    <button class="btn" id="toExplain" onclick="location.href='./explain/'">
+      説明
+    </button>
   </body>
 </html>

--- a/src/pages/learn/scripts/shuwa-item.ts
+++ b/src/pages/learn/scripts/shuwa-item.ts
@@ -1,4 +1,5 @@
 import data from "../../../../data/shuwa.json";
+import { createButtonHTML } from "../../../components/button/button";
 import type { ShuwaData, ShuwaQuizLevel, ShuwaRank } from "../../../types";
 import "../styles/shuwa-item.css";
 import { createSearchForm } from "./search-form";
@@ -48,6 +49,7 @@ document.querySelector<HTMLDivElement>(".shuwa-items")!.innerHTML = isValidId
           <p>やり方：${shuwaData[validShuwaId - 1].how_to}</p>
           <p>例文：${shuwaData[validShuwaId - 1].example_sentence}</p>
         </div>
+        ${createButtonHTML("戻る", "history.back()")}
       </div>
     `
   : `<div class="shuwa-items">
@@ -63,4 +65,5 @@ document.querySelector<HTMLDivElement>(".shuwa-items")!.innerHTML = isValidId
           `,
         )
         .join("")}
+      ${createButtonHTML("戻る", "location.href='../'")}
   </div>`;

--- a/src/pages/modeselect/index.html
+++ b/src/pages/modeselect/index.html
@@ -1,24 +1,29 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-    <head>
-        <meta charset="UTF-8">
-        <title>Mode Selection</title>
-    </head>
-    <body>
-        <input type="radio" class="modeselect" id="Reading"><label>読み取り</label>
-        <input type="radio" class="modeselect" id="Expression"><label>表現</label>
-        <input type="radio" class="modeselect" id="Dialect"><label>方言</label>
-        <br/>
-        難易度：<input type="radio" class="Difficulty" id="Easy"><label>初級</label><br/>
-        <input type="radio" class="Difficulty" id="Normal"><label>中級</label><br/>
-        <input type="radio" class="Difficulty" id="Hard"><label>上級</label><br/>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Mode Selection</title>
+  </head>
+  <body>
+    <input type="radio" class="modeselect" id="Reading" /><label
+      >読み取り</label
+    >
+    <input type="radio" class="modeselect" id="Expression" /><label>表現</label>
+    <input type="radio" class="modeselect" id="Dialect" /><label>方言</label>
+    <br />
+    難易度：<input type="radio" class="Difficulty" id="Easy" /><label
+      >初級</label
+    ><br />
+    <input type="radio" class="Difficulty" id="Normal" /><label>中級</label
+    ><br />
+    <input type="radio" class="Difficulty" id="Hard" /><label>上級</label><br />
 
-        <div id="button-container-start"></div>
-        <div id="button-container-back"></div>
+    <div id="button-container-start"></div>
+    <div id="button-container-back"></div>
 
-        <button id="quiz-start">開始</button>
-        <button id="quiz-back"  onclick="location.href='../title/'">戻る</button>
-        <!--ボタンコンポーネントの設定がうまくできなかったので普通にHTMLでボタン作りました
+    <button id="quiz-start">開始</button>
+    <button id="quiz-back" onclick="location.href='../'">戻る</button>
+    <!--ボタンコンポーネントの設定がうまくできなかったので普通にHTMLでボタン作りました
         押しても何にもならないです-->
-    </body>
+  </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   root: "./src/pages",
@@ -23,7 +26,6 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, "./src/pages/index.html"),
         learn: path.resolve(__dirname, "./src/pages/learn/index.html"),
-        title: path.resolve(__dirname, "./src/pages/title/index.html"),
         modeselect: path.resolve(
           __dirname,
           "./src/pages/modeselect/index.html",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,26 +1,40 @@
-export default {
-  appType: "mpa", // マルチページアプリケーションモードを明示的に指定
+import { defineConfig } from "vite";
+import path from "path";
+
+export default defineConfig({
+  root: "./src/pages",
+  appType: "mpa",
   server: {
     fs: {
       strict: false,
+      allow: ["../../"], // プロジェクトルート全体へのアクセスを許可
     },
     host: true,
   },
+  resolve: {
+    alias: {
+      "@data": path.resolve(__dirname, "./data"), // dataフォルダへのエイリアス
+    },
+  },
   build: {
+    outDir: "../../dist",
+    emptyOutDir: true,
     rollupOptions: {
       input: {
-        main: "./src/pages/index.html",
-        learn: "./src/pages/learn/index.html",
-        title: "./src/pages/title/index.html",
-        modeselect: "./src/pages/modeselect/index.html",
-        achieve: "./src/pages/achieve/index.html",
-        explain: "./src/pages/explain/index.html",
-        quiz: "./src/pages/quiz/index.html",
+        main: path.resolve(__dirname, "./src/pages/index.html"),
+        learn: path.resolve(__dirname, "./src/pages/learn/index.html"),
+        title: path.resolve(__dirname, "./src/pages/title/index.html"),
+        modeselect: path.resolve(
+          __dirname,
+          "./src/pages/modeselect/index.html",
+        ),
+        achieve: path.resolve(__dirname, "./src/pages/achieve/index.html"),
+        explain: path.resolve(__dirname, "./src/pages/explain/index.html"),
+        quiz: path.resolve(__dirname, "./src/pages/quiz/index.html"),
       },
     },
   },
-  // フォールバック無効化
   preview: {
     port: 4173,
   },
-};
+});


### PR DESCRIPTION
# プルリクエスト

## 🎯 概要

手話アイテム表示画面（shuwa-item.ts）に「戻る」ボタンを追加し、ユーザーが前のページや一覧ページに簡単に戻れるようにしました。

## 🛠 変更内容

- shuwa-item.tsに「戻る」ボタンを2箇所追加
  - 詳細表示時：`history.back()`で前のページに戻る
  - 一覧表示時：`location.href='../'`で一覧ページに遷移
- ボタン生成に`createButtonHTML`関数を利用

## 🔍 動作確認

- [x] 詳細画面で「戻る」ボタンを押すと前のページに戻ることを確認
- [x] 一覧画面で「戻る」ボタンを押すと一覧ページに遷移することを確認
- [x] 既存の機能に影響がないことを確認

## 📌 関連Issue

- なし

## ⚠️ 影響範囲

- learnページの手話アイテム表示機能

## 📸 スクリーンショット

<!-- UI変更を含む場合は、変更前後のスクリーンショットを添付してください -->

## 📝 備考

- 戻るボタンの配置や文言についてご意見があればご指摘ください
