### PR TITLE
feat: クイズ結果表示機能の実装

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,35 @@
-import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default tseslint.config(
+  // Global ignores
   {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
-    plugins: { js },
-    extends: ["js/recommended"],
+    ignores: ["dist", "components", ".ropeproject"],
   },
+
+  // Base configs for all files
+  ...tseslint.configs.recommended,
+
+  // Source files (browser)
   {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
-    languageOptions: { globals: globals.browser },
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
   },
-  tseslint.configs.recommended,
-]);
+
+  // Config files (node)
+  {
+    files: ['*.cjs', '*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-var-requires': 'off', // Allow require() in JS/CJS files
+    }
+  }
+);

--- a/src/pages/learn/scripts/shuwa-item.ts
+++ b/src/pages/learn/scripts/shuwa-item.ts
@@ -6,18 +6,34 @@ import { createSearchForm } from "./search-form";
 
 const shuwaData: ShuwaData[] = data as ShuwaData[];
 
+/**
+ * 特定の手話単語の詳細なHTMLコンテンツを生成します。（モーダル対応可のコンポーネント）
+ * @param shuwa - 表示する手話のデータオブジェクト
+ * @returns 生成されたHTML文字列
+ */
+export function createShuwaDetailHTML(shuwa: ShuwaData): string {
+  if (!shuwa) return "<p>該当するデータが見つかりませんでした。</p>";
+
+  return `
+    <div class="shuwa-detail">
+      <h1 class="shuwa-item-name">単語：${shuwa.name}</h1>
+      <div class="shuwa-content">
+        <div class="shuwa-video">${VideoPlayer(shuwa.youtube_url)}</div>
+        <div class="shuwa-text">
+          <p class="shuwa-how-to">やり方：${shuwa.how_to}</p>
+          <p class="shuwa-example-sentence">例文：${shuwa.example_sentence}</p>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
 const params = new URLSearchParams(window.location.search);
 const currentLevelId = (params.get("level") as ShuwaQuizLevel) || null;
 const currentRankId = (params.get("rank") as ShuwaRank) || null;
 const currentShuwaId = params.get("id");
-// URLに?id=1などがなかった場合は、nullを設定する。ある場合はidの数字を取得する。
 const validShuwaId = currentShuwaId ? Number(currentShuwaId) : null;
 
-console.log(currentRankId, currentLevelId);
-/**
- * 無効なIDかチェックをする, booleanの値を持つ定数
- * チェック内容：nullチェック, 0以上かつ手話のデータの範囲内、整数値
- */
 const isValidId =
   validShuwaId !== null &&
   Number.isInteger(validShuwaId) &&
@@ -40,32 +56,24 @@ function searchResults(
   });
 }
 
-document.querySelector<HTMLDivElement>(".shuwa-items")!.innerHTML = isValidId
-  ? `
-      <div class="shuwa-detail">
-        <h1 class="shuwa-item-name">単語：${shuwaData[validShuwaId - 1].name}</h1>
-        <div class="shuwa-content">
-          <div class="shuwa-video">${VideoPlayer(shuwaData[validShuwaId - 1].youtube_url)}</div>
-          <div class="shuwa-text">
-            <p class="shuwa-how-to">やり方：${shuwaData[validShuwaId - 1].how_to}</p>
-            <p class="shuwa-example-sentence">例文：${shuwaData[validShuwaId - 1].example_sentence}</p>
-          </div>
-        </div>
-        <button id="quiz-back" onclick="location.href='../learn/'">戻る</button>
-      </div>
-    `
-  : `${createSearchForm()}
-      ${searchResults(shuwaData, currentLevelId, currentRankId)
-        .map(
-          (shuwa) => `
-            <div class="shuwa-item">
-              <a href="./?id=${shuwa.id}">
-                <h2 class="shuwa-item-name">${shuwa.name}</h2>
-              </a>
-            </div>
-          `,
-        )
-        .join(
-          "",
-        )}     <button id="quiz-back" onclick="location.href='../title/'">戻る</button>
-`;
+// 学習ページが直接表示された場合の処理
+const shuwaItemsContainer =
+  document.querySelector<HTMLDivElement>(".shuwa-items");
+if (shuwaItemsContainer) {
+  shuwaItemsContainer.innerHTML = isValidId
+    ? `${createShuwaDetailHTML(shuwaData[validShuwaId - 1])}
+       <button id="quiz-back" onclick="location.href='../learn/'">戻る</button>`
+    : `${createSearchForm()}
+        ${searchResults(shuwaData, currentLevelId, currentRankId)
+          .map(
+            (shuwa) => `
+              <div class="shuwa-item">
+                <a href="./?id=${shuwa.id}">
+                  <h2 class="shuwa-item-name">${shuwa.name}</h2>
+                </a>
+              </div>
+            `,
+          )
+          .join("")}
+        <button id="quiz-back" onclick="location.href='../title/'">戻る</button>`;
+}

--- a/src/pages/result/index.html
+++ b/src/pages/result/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quiz</title>
+    <link
+      rel="stylesheet"
+      href="../learn/styles/shuwa-item.css"
+      media="all"
+    />
+    <link rel="stylesheet" href="./styles/result.css" />
+    <script type="module" src="./scripts/show-result.ts" defer></script>
+  </head>
+
+  <body>
+    <div class="result-container"></div>
+    <div class="shuwa-modal"></div>
+  </body>
+</html>

--- a/src/pages/result/index.html
+++ b/src/pages/result/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quiz</title>
+    <title>Result</title>
     <link
       rel="stylesheet"
       href="../learn/styles/shuwa-item.css"

--- a/src/pages/result/scripts/show-result.ts
+++ b/src/pages/result/scripts/show-result.ts
@@ -31,7 +31,7 @@ function resultItems(): string {
     `;
     })
     .join("")}
-  `;
+  <button id="quiz-back" onclick="location.href='../title/'">戻る</button>`;
 }
 
 /**

--- a/src/pages/result/scripts/show-result.ts
+++ b/src/pages/result/scripts/show-result.ts
@@ -1,0 +1,81 @@
+import { createShuwaDetailHTML } from "../../learn/scripts/shuwa-item";
+import type { ShuwaData } from "../../../types";
+import data from "../../../../data/shuwa.json";
+
+const shuwaData: ShuwaData[] = data as ShuwaData[];
+
+/**
+ * クイズ結果のHTML要素を生成する
+ */
+function resultItems(): string {
+  // TODO: クイズ機能実装後に、実際のクイズ結果をlocalStorageから取得するように修正する
+  localStorage.setItem(
+    "results",
+    JSON.stringify(new Array(10).fill(false).map(() => Math.random() > 0.5)),
+  );
+
+  const results: boolean[] | null = JSON.parse(
+    localStorage.getItem("results") || "[]",
+  );
+  if (!results) return "結果の情報がありません。";
+
+  return `
+  ${results
+    .map((result: boolean, index: number) => {
+      return `
+      <div class="result-item">
+        <h2>第${index + 1}問</h2>
+        <p>${result ? "○" : "×"}</p>
+        <button class="explanation-button" data-index="${index}">解説</button>
+      </div>
+    `;
+    })
+    .join("")}
+  `;
+}
+
+/**
+ * 指定された問題の解説モーダルを表示する
+ * @param index 解説を表示する問題のインデックス
+ */
+function showExplanation(index: number) {
+  const shuwaModal = document.querySelector<HTMLDivElement>(".shuwa-modal");
+  if (!shuwaModal) return;
+
+  const detailHTML = createShuwaDetailHTML(shuwaData[index]);
+
+  const contentWithCloseButton = `
+    ${detailHTML}
+    <button class="modal-close-button">×</button>
+  `;
+
+  shuwaModal.innerHTML = contentWithCloseButton;
+  shuwaModal.classList.add("is-visible");
+
+  const closeButton = shuwaModal.querySelector(".modal-close-button");
+  closeButton?.addEventListener("click", () => {
+    shuwaModal.classList.remove("is-visible");
+    // モーダルを閉じる際に、内容を空にしてメモリリークや意図しない動作を防ぐ
+    shuwaModal.innerHTML = "";
+  });
+}
+
+/**
+ * クイズ結果画面を初期化し、イベントリスナーを設定する
+ */
+function showResult() {
+  const resultContainer = document.querySelector(".result-container");
+  if (!resultContainer) return;
+
+  resultContainer.innerHTML = resultItems();
+
+  const explanationButtons = resultContainer.querySelectorAll(
+    ".explanation-button",
+  );
+  explanationButtons.forEach((button) => {
+    const buttonIndex = parseInt(button.getAttribute("data-index") || "0", 10);
+    button.addEventListener("click", () => showExplanation(buttonIndex));
+  });
+}
+
+showResult();

--- a/src/pages/result/styles/result.css
+++ b/src/pages/result/styles/result.css
@@ -1,0 +1,38 @@
+.shuwa-modal {
+  display: none; /* デフォルトでは非表示 */
+  position: fixed; /* 画面に固定 */
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7); /* 半透明の背景 */
+  z-index: 1000; /* 他の要素より手前に表示 */
+  overflow-y: auto; /* 内容が多ければスクロール */
+}
+
+.shuwa-modal.is-visible {
+  display: flex; /* is-visibleクラスが付いたら表示 */
+  align-items: center;
+  justify-content: center;
+}
+
+.shuwa-modal .shuwa-detail {
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 800px;
+  width: 90%;
+  position: relative;
+}
+
+.modal-close-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #ff0000;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default {
         achieve: "./src/pages/achieve/index.html",
         explain: "./src/pages/explain/index.html",
         quiz: "./src/pages/quiz/index.html",
+        result: "./src/pages/result/index.html",
       },
     },
   },


### PR DESCRIPTION
# プルリクエスト

## 🎯 概要

クイズ機能の一部として、クイズ結果を表示し、各問題の解説を確認できる画面を実装しました。

## 🛠 変更内容

- クイズ結果ページの基本的なUIとロジックを実装
- 解説モーダルをコンポーネント化し、結果ページで再利用
- Viteのビルド設定に新しい結果ページを追加
- ESLintの設定を更新し、不要なファイルを無視するように修正

## 🔍 動作確認

- [x] クイズ結果ページが正しく表示される
- [x] 各問題の「解説」ボタンをクリックすると、手話の詳細モーダルが表示される
- [x] モーダルの「×」ボタンで解説を閉じることができる
- [x] `pnpm lint`がエラーなくパスする

## 📌 関連Issue

#30

## ⚠️ 影響範囲

- クイズ機能
- 学習機能（手話詳細コンポーネントを共有）

## 📸 スクリーンショット

<img width="1926" height="955" alt="スクリーンショット 2025-07-31 15 03 25" src="https://github.com/user-attachments/assets/a9220ac1-01d6-4fa5-833a-68b5a7589423" />


## 📝 備考

`learn`ページで使われていた手話詳細表示のロジックを、`result`ページでも使えるように共通コンポーネント化��ました。
