### PR TITLE
fix: 結果ページが表示されないバグを修正

### DIFF
--- a/src/components/shuwa-detail/shuwa-detail.ts
+++ b/src/components/shuwa-detail/shuwa-detail.ts
@@ -1,0 +1,24 @@
+import VideoPlayer from "../video/video-player";
+import type { ShuwaData } from "../../types";
+
+/**
+ * 特定の手話単語の詳細なHTMLコンテンツを生成します。（モーダル対応可のコンポーネント）
+ * @param shuwa - 表示する手話のデータオブジェクト
+ * @returns 生成されたHTML文字列
+ */
+export function createShuwaDetailHTML(shuwa: ShuwaData): string {
+  if (!shuwa) return "<p>該当するデータが見つかりませんでした。</p>";
+
+  return `
+    <div class="shuwa-detail">
+      <h1 class="shuwa-item-name">単語：${shuwa.name}</h1>
+      <div class="shuwa-content">
+        <div class="shuwa-video">${VideoPlayer(shuwa.youtube_url)}</div>
+        <div class="shuwa-text">
+          <p class="shuwa-how-to">やり方：${shuwa.how_to}</p>
+          <p class="shuwa-example-sentence">例文：${shuwa.example_sentence}</p>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/src/pages/learn/scripts/shuwa-item.ts
+++ b/src/pages/learn/scripts/shuwa-item.ts
@@ -1,33 +1,12 @@
 import data from "../../../../data/shuwa.json";
 import { createButtonHTML } from "../../../components/button/button";
+import { createShuwaDetailHTML } from "../../../components/shuwa-detail/shuwa-detail";
 import VideoPlayer from "../../../components/video/video-player";
 import type { ShuwaData, ShuwaQuizLevel, ShuwaRank } from "../../../types";
 import "../styles/shuwa-item.css";
 import { createSearchForm } from "./search-form";
 
 const shuwaData: ShuwaData[] = data as ShuwaData[];
-
-/**
- * 特定の手話単語の詳細なHTMLコンテンツを生成します。（モーダル対応可のコンポーネント）
- * @param shuwa - 表示する手話のデータオブジェクト
- * @returns 生成されたHTML文字列
- */
-export function createShuwaDetailHTML(shuwa: ShuwaData): string {
-  if (!shuwa) return "<p>該当するデータが見つかりませんでした。</p>";
-
-  return `
-    <div class="shuwa-detail">
-      <h1 class="shuwa-item-name">単語：${shuwa.name}</h1>
-      <div class="shuwa-content">
-        <div class="shuwa-video">${VideoPlayer(shuwa.youtube_url)}</div>
-        <div class="shuwa-text">
-          <p class="shuwa-how-to">やり方：${shuwa.how_to}</p>
-          <p class="shuwa-example-sentence">例文：${shuwa.example_sentence}</p>
-        </div>
-      </div>
-    </div>
-  `;
-}
 
 const params = new URLSearchParams(window.location.search);
 const currentLevelId = (params.get("level") as ShuwaQuizLevel) || null;

--- a/src/pages/quiz/scripts/quiz.ts
+++ b/src/pages/quiz/scripts/quiz.ts
@@ -28,12 +28,6 @@ const modal = document.getElementById("result-modal") as HTMLDivElement;
 const modalMessage = document.getElementById(
   "modal-message",
 ) as HTMLParagraphElement;
-const correctAnswerVideo = document.getElementById(
-  "correct-answer-video",
-) as HTMLVideoElement;
-const yourAnswerVideo = document.getElementById(
-  "your-answer-video",
-) as HTMLVideoElement;
 const nextButton = document.getElementById("next-button") as HTMLButtonElement;
 
 // --- クイズの状態管理 ---
@@ -164,6 +158,6 @@ function showFinalResult() {
 // 終了ボタン
 retireButton.addEventListener("click", () => {
   if (confirm("クイズを中断してタイトルに戻りますか？")) {
-    window.location.href = "../title/"; // タイトル画面のパス
+    window.location.href = "../"; // タイトル画面のパス
   }
 });

--- a/src/pages/result/scripts/show-result.ts
+++ b/src/pages/result/scripts/show-result.ts
@@ -1,4 +1,4 @@
-import { createShuwaDetailHTML } from "../../learn/scripts/shuwa-item";
+import { createShuwaDetailHTML } from "../../../components/shuwa-detail/shuwa-detail";
 import type { ShuwaData } from "../../../types";
 import data from "../../../../data/shuwa.json";
 


### PR DESCRIPTION
## 🎯 概要
クイズ完了後の結果ページ(/result/)で何も表示されないバグを修正しました。ユーザーがクイズを最後まで完了できるようになります。

## 🛠 変更内容

### 根本原因
- `result/show-result.ts`が`learn/shuwa-item.ts`からimportしていた
- `shuwa-item.ts`実行時に存在しない`.shuwa-items`要素にアクセスしてTypeErrorが発生
- 結果ページのレンダリングが停止していた

### 修正内容
- **コンポーネント分離**: `createShuwaDetailHTML`関数を独立したコンポーネント`src/components/shuwa-detail/shuwa-detail.ts`に移動
- **安全なimport**: 結果ページから分離されたコンポーネントを安全にimport
- **パス修正**: クイズ終了ボタンの遷移先を`../title/`から`../`に修正

### ファイル変更
- 新規作成: `src/components/shuwa-detail/shuwa-detail.ts`
- 修正: `src/pages/result/scripts/show-result.ts`（import先変更）
- 修正: `src/pages/learn/scripts/shuwa-item.ts`（関数移動・import追加）
- 修正: `src/pages/quiz/scripts/quiz.ts`（パス修正）

## 🔍 動作確認

- [x] 読み取り・初級クイズを7問完答
- [x] アラートで「7問中2問正解」が表示
- [x] 結果ページへの自動遷移が成功
- [x] 全7問の正解/不正解が正確に表示
- [x] 各問題の解説ボタンが動作
- [x] 解説モーダルの開閉が正常動作

## 📌 関連Issue

結果ページ表示バグ（ユーザー報告）

## ⚠️ 影響範囲

- クイズ結果表示機能
- 学習モードの詳細表示機能（コンポーネント分離により改善）
- クイズ終了時の画面遷移

## 📝 備考

アーキテクチャの改善により、コンポーネントの再利用性も向上しました。今後同様の循環参照問題を防げます。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>