### PR TITLE
feat: アチーブメント機能の実装とCSS相対単位対応

### DIFF
--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -2,3 +2,4 @@
 export const ACHIEVEMENT_STORAGE_KEY = "shuwa-achievements";
 export const LEARNED_SHUWA_COUNT_KEY = "learned-shuwa-count";
 export const LEARNED_SHUWA_LIST_KEY = "learned-shuwa-list";
+export const QUIZ_COUNT_KEY = "quiz-count";

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,0 +1,4 @@
+// LocalStorage key for all achievements
+export const ACHIEVEMENT_STORAGE_KEY = "shuwa-achievements";
+export const LEARNED_SHUWA_COUNT_KEY = "learned-shuwa-count";
+export const LEARNED_SHUWA_LIST_KEY = "learned-shuwa-list";

--- a/src/pages/achieve/scripts/show-achive.ts
+++ b/src/pages/achieve/scripts/show-achive.ts
@@ -218,11 +218,11 @@ function checkLearnedAchievements(
 }
 
 function checkQuizAchievements(achievements: AchievementData): AchievementData {
-  const lerarnedShuwaCount = localStorage.getItem(QUIZ_COUNT_KEY);
+  const learnedShuwaCount = localStorage.getItem(QUIZ_COUNT_KEY);
   for (const learnedShuwa of QUIZ_COUNT) {
     if (
-      lerarnedShuwaCount &&
-      parseInt(lerarnedShuwaCount) >= learnedShuwa.value
+      learnedShuwaCount &&
+      parseInt(learnedShuwaCount) >= learnedShuwa.value
     ) {
       achievements[learnedShuwa.key] = true;
     }

--- a/src/pages/achieve/scripts/show-achive.ts
+++ b/src/pages/achieve/scripts/show-achive.ts
@@ -1,6 +1,7 @@
 import {
   ACHIEVEMENT_STORAGE_KEY,
   LEARNED_SHUWA_COUNT_KEY,
+  QUIZ_COUNT_KEY,
 } from "../../../constants/localStorage";
 
 // Achievement system for 手話ぷら
@@ -9,6 +10,11 @@ interface AchievementData {
 }
 
 interface ShuwaLearnedCount {
+  key: string;
+  value: number;
+}
+
+interface QuizCount {
   key: string;
   value: number;
 }
@@ -25,6 +31,47 @@ const SHUWA_LEARNED_COUNT: ShuwaLearnedCount[] = [
   { key: "kagimoto-5", value: 300 },
   { key: "fukuda-2", value: 50 },
 ];
+
+// クイズで解いた数
+const QUIZ_COUNT: QuizCount[] = [
+  {
+    key: "itoga-4",
+    value: 70,
+  },
+  {
+    key: "imamura-1",
+    value: 20,
+  },
+  {
+    key: "imamura-5",
+    value: 250,
+  },
+  {
+    key: "uchimura-3",
+    value: 150,
+  },
+  {
+    key: "uchimura-7",
+    value: 600,
+  },
+  {
+    key: "reader-4",
+    value: 1,
+  },
+  {
+    key: "kagimoto-7",
+    value: 100,
+  },
+  {
+    key: "fukuda-1",
+    value: 400,
+  },
+  {
+    key: "fukuda",
+    value: 20,
+  },
+];
+
 // Team member hiragana characters
 const MEMBER_CHARACTERS = {
   itoga: ["い", "と", "が", "た", "い", "よ", "う"],
@@ -142,6 +189,7 @@ function initializeAchievements(): void {
   const achievements = getAchievements();
 
   checkLearnedAchievements(achievements);
+  checkQuizAchievements(achievements);
   updateAchievementUI();
 }
 
@@ -158,6 +206,20 @@ function checkLearnedAchievements(
 ): AchievementData {
   const lerarnedShuwaCount = localStorage.getItem(LEARNED_SHUWA_COUNT_KEY);
   for (const learnedShuwa of SHUWA_LEARNED_COUNT) {
+    if (
+      lerarnedShuwaCount &&
+      parseInt(lerarnedShuwaCount) >= learnedShuwa.value
+    ) {
+      achievements[learnedShuwa.key] = true;
+    }
+  }
+  saveAchievements(achievements);
+  return achievements;
+}
+
+function checkQuizAchievements(achievements: AchievementData): AchievementData {
+  const lerarnedShuwaCount = localStorage.getItem(QUIZ_COUNT_KEY);
+  for (const learnedShuwa of QUIZ_COUNT) {
     if (
       lerarnedShuwaCount &&
       parseInt(lerarnedShuwaCount) >= learnedShuwa.value

--- a/src/pages/achieve/scripts/show-achive.ts
+++ b/src/pages/achieve/scripts/show-achive.ts
@@ -1,11 +1,30 @@
+import {
+  ACHIEVEMENT_STORAGE_KEY,
+  LEARNED_SHUWA_COUNT_KEY,
+} from "../../../constants/localStorage";
+
 // Achievement system for 手話ぷら
 interface AchievementData {
   [key: string]: boolean;
 }
 
-// LocalStorage key for all achievements
-const ACHIEVEMENT_STORAGE_KEY = "shuwa-achievements";
+interface ShuwaLearnedCount {
+  key: string;
+  value: number;
+}
 
+// 学習した数の条件の配列
+const SHUWA_LEARNED_COUNT: ShuwaLearnedCount[] = [
+  { key: "itoga-1", value: 1 },
+  { key: "itoga-7", value: 200 },
+  { key: "imamura-3", value: 100 },
+  { key: "uchimura-1", value: 319 },
+  { key: "uchimura-5", value: 500 },
+  { key: "reader-1", value: 159 },
+  { key: "kagimoto-2", value: 30 },
+  { key: "kagimoto-5", value: 300 },
+  { key: "fukuda-2", value: 50 },
+];
 // Team member hiragana characters
 const MEMBER_CHARACTERS = {
   itoga: ["い", "と", "が", "た", "い", "よ", "う"],
@@ -122,29 +141,33 @@ function updateAchievementUI(): void {
 function initializeAchievements(): void {
   const achievements = getAchievements();
 
-  // For demo: add some completed achievements if none exist
-  if (Object.keys(achievements).length === 0) {
-    achievements["itoga-1"] = true;
-    achievements["itoga-2"] = true;
-    achievements["uchimura-4"] = true;
-    achievements["uchimura-5"] = true;
-    achievements["kagimoto-1"] = true;
-    saveAchievements(achievements);
-  }
-
+  checkLearnedAchievements(achievements);
   updateAchievementUI();
 }
 
 // Public API for other parts of the app to unlock achievements
-function unlockAchievement(achievementId: string): void {
+export function unlockAchievement(achievementId: string): void {
   const achievements = getAchievements();
   achievements[achievementId] = true;
   saveAchievements(achievements);
   updateAchievementUI();
 }
 
+function checkLearnedAchievements(
+  achievements: AchievementData,
+): AchievementData {
+  const lerarnedShuwaCount = localStorage.getItem(LEARNED_SHUWA_COUNT_KEY);
+  for (const learnedShuwa of SHUWA_LEARNED_COUNT) {
+    if (
+      lerarnedShuwaCount &&
+      parseInt(lerarnedShuwaCount) >= learnedShuwa.value
+    ) {
+      achievements[learnedShuwa.key] = true;
+    }
+  }
+  saveAchievements(achievements);
+  return achievements;
+}
+
 // Initialize on page load
 document.addEventListener("DOMContentLoaded", initializeAchievements);
-
-// Export for use by other scripts
-(window as any).unlockAchievement = unlockAchievement;

--- a/src/pages/achieve/scripts/show-achive.ts
+++ b/src/pages/achieve/scripts/show-achive.ts
@@ -156,11 +156,11 @@ export function unlockAchievement(achievementId: string): void {
 function checkLearnedAchievements(
   achievements: AchievementData,
 ): AchievementData {
-  const lerarnedShuwaCount = localStorage.getItem(LEARNED_SHUWA_COUNT_KEY);
+  const learnedShuwaCount = localStorage.getItem(LEARNED_SHUWA_COUNT_KEY);
   for (const learnedShuwa of SHUWA_LEARNED_COUNT) {
     if (
-      lerarnedShuwaCount &&
-      parseInt(lerarnedShuwaCount) >= learnedShuwa.value
+      learnedShuwaCount &&
+      parseInt(learnedShuwaCount) >= learnedShuwa.value
     ) {
       achievements[learnedShuwa.key] = true;
     }

--- a/src/pages/learn/scripts/shuwa-item.ts
+++ b/src/pages/learn/scripts/shuwa-item.ts
@@ -1,6 +1,10 @@
 import data from "../../../../data/shuwa.json";
 import { createButtonHTML } from "../../../components/button/button";
-import VideoPlayer from "../../../components/video/video-player";
+import { createShuwaDetailHTML } from "../../../components/shuwa-detail/shuwa-detail";
+import {
+  LEARNED_SHUWA_COUNT_KEY,
+  LEARNED_SHUWA_LIST_KEY,
+} from "../../../constants/localStorage";
 import type { ShuwaData, ShuwaQuizLevel, ShuwaRank } from "../../../types";
 import "../styles/shuwa-item.css";
 import { createSearchForm } from "./search-form";
@@ -56,19 +60,18 @@ const shuwaItemsContainer =
 document.body.className = "theme-nature";
 
 if (isValidId) {
+  const learnedShuwas: string[] =
+    localStorage.getItem(LEARNED_SHUWA_LIST_KEY)?.split(",") || [];
+  if (currentShuwaId && !learnedShuwas.includes(currentShuwaId.toString())) {
+    learnedShuwas.push(currentShuwaId.toString());
+    localStorage.setItem(LEARNED_SHUWA_LIST_KEY, learnedShuwas.join(","));
+    const shuwaCount = learnedShuwas.length;
+    localStorage.setItem(LEARNED_SHUWA_COUNT_KEY, shuwaCount.toString());
+  }
   shuwaItemsContainer.innerHTML = `
-      <div class="shuwa-detail">
-        <h1 class="shuwa-item-name">単語：${shuwaData[validShuwaId - 1].name}</h1>
-        <div class="shuwa-content">
-          <div class="shuwa-video">${VideoPlayer(shuwaData[validShuwaId - 1].youtube_url)}</div>
-          <div class="shuwa-text">
-            <p class="shuwa-how-to">やり方：${shuwaData[validShuwaId - 1].how_to}</p>
-            <p class="shuwa-example-sentence">例文：${shuwaData[validShuwaId - 1].example_sentence}</p>
-          </div>
-        </div>
-        ${createButtonHTML("戻る", "history.back()")}
-      </div>
-    `;
+    ${createShuwaDetailHTML(shuwaData[validShuwaId - 1])}
+    ${createButtonHTML("戻る", "history.back()")}
+  `;
 } else {
   shuwaItemsContainer.innerHTML = `
     ${createSearchForm()}

--- a/src/pages/learn/styles/search-form.css
+++ b/src/pages/learn/styles/search-form.css
@@ -2,31 +2,30 @@
 .shuwa-search-form {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 0.75rem;
   align-items: center;
-  padding: 20px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-radius: 12px;
-  margin-bottom: 24px;
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1.5rem;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
 /* 検索テキスト入力 */
 .shuwa-search-form input[type="text"] {
   flex: 1;
-  min-width: 200px;
-  padding: 12px 16px;
+  min-width: 12.5rem;
+  padding: 0.75rem 1rem;
   border: none;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: rgba(255, 255, 255, 0.9);
-  font-size: 16px;
+  font-size: 1rem;
   transition: all 0.3s ease;
 }
 
 .shuwa-search-form input[type="text"]:focus {
   outline: none;
   background: white;
-  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 0 0 0.1875rem rgba(102, 126, 234, 0.3);
 }
 
 .shuwa-search-form input[type="text"]::placeholder {
@@ -35,20 +34,20 @@
 
 /* セレクトボックス共通スタイル */
 .shuwa-search-form select {
-  padding: 12px 16px;
+  padding: 0.75rem 1rem;
   border: none;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: rgba(255, 255, 255, 0.9);
-  font-size: 16px;
+  font-size: 1rem;
   cursor: pointer;
   transition: all 0.3s ease;
-  min-width: 160px;
+  min-width: 10rem;
 }
 
 .shuwa-search-form select:focus {
   outline: none;
   background: white;
-  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 0 0 0.1875rem rgba(102, 126, 234, 0.3);
 }
 
 /* 階級選択 */
@@ -63,21 +62,21 @@
 
 /* 検索ボタン */
 .shuwa-search-form button {
-  padding: 12px 24px;
+  padding: 0.75rem 1.5rem;
   background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
   color: white;
   border: none;
-  border-radius: 8px;
-  font-size: 16px;
+  border-radius: 0.5rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(245, 87, 108, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(245, 87, 108, 0.3);
 }
 
 .shuwa-search-form button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(245, 87, 108, 0.4);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.9375rem rgba(245, 87, 108, 0.4);
 }
 
 .shuwa-search-form button:active {
@@ -85,7 +84,7 @@
 }
 
 /* レスポンシブ対応 */
-@media (max-width: 768px) {
+@media (max-width: 48rem) {
   .shuwa-search-form {
     flex-direction: column;
     align-items: stretch;
@@ -116,11 +115,11 @@ body.theme-nature .shuwa-search-form select:focus {
 
 body.theme-nature .shuwa-search-form button {
   background: linear-gradient(135deg, #4caf50 0%, #8bc34a 100%);
-  box-shadow: 0 2px 8px rgba(76, 175, 80, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(76, 175, 80, 0.3);
 }
 
 body.theme-nature .shuwa-search-form button:hover {
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.4);
 }
 
 /* Sunset Theme */
@@ -138,11 +137,11 @@ body.theme-sunset .shuwa-search-form select:focus {
 
 body.theme-sunset .shuwa-search-form button {
   background: linear-gradient(135deg, #ff7043 0%, #ffab40 100%);
-  box-shadow: 0 2px 8px rgba(255, 112, 67, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(255, 112, 67, 0.3);
 }
 
 body.theme-sunset .shuwa-search-form button:hover {
-  box-shadow: 0 4px 15px rgba(255, 112, 67, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(255, 112, 67, 0.4);
 }
 
 /* Ocean Theme */
@@ -160,23 +159,23 @@ body.theme-ocean .shuwa-search-form select:focus {
 
 body.theme-ocean .shuwa-search-form button {
   background: linear-gradient(135deg, #0288d1 0%, #0097a7 100%);
-  box-shadow: 0 2px 8px rgba(2, 136, 209, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(2, 136, 209, 0.3);
 }
 
 body.theme-ocean .shuwa-search-form button:hover {
-  box-shadow: 0 4px 15px rgba(2, 136, 209, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(2, 136, 209, 0.4);
 }
 
 /* Dark Mode Theme */
 body.theme-dark .shuwa-search-form {
   background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0.25rem 0.9375rem rgba(0, 0, 0, 0.3);
 }
 
 body.theme-dark .shuwa-search-form input[type="text"] {
   background: rgba(255, 255, 255, 0.1);
   color: #e2e8f0;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 0.0625rem solid rgba(255, 255, 255, 0.1);
 }
 
 body.theme-dark .shuwa-search-form input[type="text"]:focus {
@@ -192,7 +191,7 @@ body.theme-dark .shuwa-search-form input[type="text"]::placeholder {
 body.theme-dark .shuwa-search-form select {
   background: rgba(255, 255, 255, 0.1);
   color: #e2e8f0;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 0.0625rem solid rgba(255, 255, 255, 0.1);
 }
 
 body.theme-dark .shuwa-search-form select:focus {
@@ -203,52 +202,52 @@ body.theme-dark .shuwa-search-form select:focus {
 
 body.theme-dark .shuwa-search-form button {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 0.125rem 0.5rem rgba(102, 126, 234, 0.4);
 }
 
 body.theme-dark .shuwa-search-form button:hover {
-  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.5);
+  box-shadow: 0 0.25rem 0.9375rem rgba(102, 126, 234, 0.5);
 }
 
 /* Minimal Theme */
 body.theme-minimal .shuwa-search-form {
   background: #ffffff;
-  border: 2px solid #e5e7eb;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 0.125rem solid #e5e7eb;
+  box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-search-form input[type="text"] {
   background: #f9fafb;
-  border: 1px solid #d1d5db;
+  border: 0.0625rem solid #d1d5db;
   color: #374151;
 }
 
 body.theme-minimal .shuwa-search-form input[type="text"]:focus {
   background: #ffffff;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 0 0.125rem rgba(59, 130, 246, 0.3);
   border-color: #3b82f6;
 }
 
 body.theme-minimal .shuwa-search-form select {
   background: #f9fafb;
-  border: 1px solid #d1d5db;
+  border: 0.0625rem solid #d1d5db;
   color: #374151;
 }
 
 body.theme-minimal .shuwa-search-form select:focus {
   background: #ffffff;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 0 0.125rem rgba(59, 130, 246, 0.3);
   border-color: #3b82f6;
 }
 
 body.theme-minimal .shuwa-search-form button {
   background: #3b82f6;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-search-form button:hover {
   background: #2563eb;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
 }
 
 /* =================================== */
@@ -257,29 +256,29 @@ body.theme-minimal .shuwa-search-form button:hover {
 
 .layout-switcher {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: center;
 }
 
 .layout-btn {
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 6px;
+  border: 0.0625rem solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.375rem;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 14px;
+  font-size: 0.875rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 36px;
-  height: 36px;
+  min-width: 2.25rem;
+  height: 2.25rem;
 }
 
 .layout-btn:hover {
   background: white;
   border-color: rgba(0, 0, 0, 0.2);
-  transform: translateY(-1px);
+  transform: translateY(-0.0625rem);
 }
 
 .layout-btn.active {

--- a/src/pages/learn/styles/shuwa-item.css
+++ b/src/pages/learn/styles/shuwa-item.css
@@ -2,9 +2,6 @@
 body {
   margin: 0;
   padding: 0;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-    Arial, sans-serif;
   min-height: 100vh;
   overflow-y: auto; /* 縦スクロールを有効化 */
 }
@@ -14,35 +11,59 @@ body {
   position: relative; /* 重なり順の基準点を作成 */
   flex: 1 1 auto; /* コンテナ内で伸縮 */
   overflow-y: auto; /* 縦スクロールを有効化 */
-  padding: 20px;
-  max-width: 1200px;
+  padding: 1.25rem;
+  max-width: 100%;
   margin: 0 auto;
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-/* 手話アイテムグリッド（3列レイアウト） */
+/* 手話アイテムグリッド（レスポンシブレイアウト） */
 .shuwa-items-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  margin-top: 20px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+
+/* ワイド画面での5列表示 */
+@media (min-width: 90rem) {
+  .shuwa-items-grid {
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+/* 大画面での4列表示 */
+@media (min-width: 75rem) and (max-width: 89.99rem) {
+  .shuwa-items-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+/* 標準画面での3列表示 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .shuwa-items-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+  }
 }
 
 /* 個別手話アイテム */
 .shuwa-item {
   background: white;
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: 0 0.25rem 0.9375rem rgba(0, 0, 0, 0.08);
   transition: all 0.3s ease;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border: 0.0625rem solid rgba(0, 0, 0, 0.05);
 }
 
 .shuwa-item:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  transform: translateY(-0.25rem);
+  box-shadow: 0 0.5rem 1.5625rem rgba(0, 0, 0, 0.15);
   border-color: rgba(102, 126, 234, 0.2);
 }
 
@@ -56,11 +77,11 @@ body {
 /* 手話アイテムの名前 */
 .shuwa-item-name {
   margin: 0;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 600;
   color: #1f2937;
   text-align: center;
-  padding: 12px 0;
+  padding: 0.75rem 0;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   background-clip: text;
   -webkit-background-clip: text;
@@ -74,25 +95,25 @@ body {
 
 /* 戻るボタンスタイル */
 .shuwa-items button {
-  margin-top: 24px;
-  padding: 12px 24px;
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
   background: linear-gradient(135deg, #6b73ff 0%, #9636ff 100%);
   color: white;
   border: none;
-  border-radius: 8px;
-  font-size: 16px;
+  border-radius: 0.5rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(107, 115, 255, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(107, 115, 255, 0.3);
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
 
 .shuwa-items button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(107, 115, 255, 0.4);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.9375rem rgba(107, 115, 255, 0.4);
 }
 
 .shuwa-items button:active {
@@ -102,16 +123,20 @@ body {
 /* 詳細ページスタイル */
 .shuwa-items > div:not(.shuwa-item) {
   background: white;
-  border-radius: 16px;
-  padding: 30px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
-  margin-top: 20px;
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 0.375rem 1.25rem rgba(0, 0, 0, 0.1);
+  margin-top: 1.25rem;
+  max-width: 98%;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .shuwa-items h1 {
   color: #1f2937;
-  font-size: 28px;
-  margin-bottom: 24px;
+  font-size: 2.5rem;
+  margin-bottom: 2rem;
   text-align: center;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   background-clip: text;
@@ -120,7 +145,7 @@ body {
 }
 
 .shuwa-items div > div {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 
 .shuwa-items a {
@@ -137,40 +162,40 @@ body {
 .shuwa-items p {
   color: #4b5563;
   line-height: 1.6;
-  margin: 12px 0;
+  margin: 0.75rem 0;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* タブレット・モバイル対応 */
+@media (max-width: 48rem) {
   .shuwa-items {
-    padding: 15px;
+    padding: 0.9375rem;
   }
 
   .shuwa-items-grid {
     grid-template-columns: repeat(2, 1fr);
-    gap: 15px;
+    gap: 0.9375rem;
   }
 
   .shuwa-item {
-    padding: 15px;
+    padding: 0.9375rem;
   }
 
   .shuwa-item-name {
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   .shuwa-items h1 {
-    font-size: 24px;
+    font-size: 1.75rem;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 30rem) {
   .shuwa-items-grid {
     grid-template-columns: 1fr;
   }
 
   .shuwa-items h1 {
-    font-size: 20px;
+    font-size: 1.5rem;
   }
 }
 
@@ -185,12 +210,12 @@ body.theme-nature {
 
 body.theme-nature .shuwa-item {
   background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(76, 175, 80, 0.1);
+  border: 0.0625rem solid rgba(76, 175, 80, 0.1);
 }
 
 body.theme-nature .shuwa-item:hover {
   border-color: rgba(76, 175, 80, 0.3);
-  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.15);
+  box-shadow: 0 0.5rem 1.5625rem rgba(76, 175, 80, 0.15);
 }
 
 body.theme-nature .shuwa-item-name {
@@ -202,11 +227,11 @@ body.theme-nature .shuwa-item-name {
 
 body.theme-nature .shuwa-items button {
   background: linear-gradient(135deg, #4caf50 0%, #66bb6a 100%);
-  box-shadow: 0 2px 8px rgba(76, 175, 80, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(76, 175, 80, 0.3);
 }
 
 body.theme-nature .shuwa-items button:hover {
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.4);
 }
 
 body.theme-nature .shuwa-items h1 {
@@ -218,7 +243,7 @@ body.theme-nature .shuwa-items h1 {
 
 body.theme-nature .shuwa-items > div:not(.shuwa-item) {
   background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.1);
+  box-shadow: 0 0.375rem 1.25rem rgba(76, 175, 80, 0.1);
 }
 
 /* Sunset Theme */
@@ -228,12 +253,12 @@ body.theme-sunset {
 
 body.theme-sunset .shuwa-item {
   background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(255, 112, 67, 0.1);
+  border: 0.0625rem solid rgba(255, 112, 67, 0.1);
 }
 
 body.theme-sunset .shuwa-item:hover {
   border-color: rgba(255, 112, 67, 0.3);
-  box-shadow: 0 8px 25px rgba(255, 112, 67, 0.15);
+  box-shadow: 0 0.5rem 1.5625rem rgba(255, 112, 67, 0.15);
 }
 
 body.theme-sunset .shuwa-item-name {
@@ -245,11 +270,11 @@ body.theme-sunset .shuwa-item-name {
 
 body.theme-sunset .shuwa-items button {
   background: linear-gradient(135deg, #ff7043 0%, #ffab40 100%);
-  box-shadow: 0 2px 8px rgba(255, 112, 67, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(255, 112, 67, 0.3);
 }
 
 body.theme-sunset .shuwa-items button:hover {
-  box-shadow: 0 4px 15px rgba(255, 112, 67, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(255, 112, 67, 0.4);
 }
 
 body.theme-sunset .shuwa-items h1 {
@@ -261,7 +286,7 @@ body.theme-sunset .shuwa-items h1 {
 
 body.theme-sunset .shuwa-items > div:not(.shuwa-item) {
   background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 6px 20px rgba(255, 112, 67, 0.1);
+  box-shadow: 0 0.375rem 1.25rem rgba(255, 112, 67, 0.1);
 }
 
 /* Ocean Theme */
@@ -271,12 +296,12 @@ body.theme-ocean {
 
 body.theme-ocean .shuwa-item {
   background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(0, 151, 167, 0.1);
+  border: 0.0625rem solid rgba(0, 151, 167, 0.1);
 }
 
 body.theme-ocean .shuwa-item:hover {
   border-color: rgba(0, 151, 167, 0.3);
-  box-shadow: 0 8px 25px rgba(0, 151, 167, 0.15);
+  box-shadow: 0 0.5rem 1.5625rem rgba(0, 151, 167, 0.15);
 }
 
 body.theme-ocean .shuwa-item-name {
@@ -288,11 +313,11 @@ body.theme-ocean .shuwa-item-name {
 
 body.theme-ocean .shuwa-items button {
   background: linear-gradient(135deg, #0288d1 0%, #0097a7 100%);
-  box-shadow: 0 2px 8px rgba(2, 136, 209, 0.3);
+  box-shadow: 0 0.125rem 0.5rem rgba(2, 136, 209, 0.3);
 }
 
 body.theme-ocean .shuwa-items button:hover {
-  box-shadow: 0 4px 15px rgba(2, 136, 209, 0.4);
+  box-shadow: 0 0.25rem 0.9375rem rgba(2, 136, 209, 0.4);
 }
 
 body.theme-ocean .shuwa-items h1 {
@@ -304,7 +329,7 @@ body.theme-ocean .shuwa-items h1 {
 
 body.theme-ocean .shuwa-items > div:not(.shuwa-item) {
   background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 6px 20px rgba(0, 151, 167, 0.1);
+  box-shadow: 0 0.375rem 1.25rem rgba(0, 151, 167, 0.1);
 }
 
 /* Dark Mode Theme */
@@ -315,14 +340,14 @@ body.theme-dark {
 
 body.theme-dark .shuwa-item {
   background: rgba(45, 55, 72, 0.8);
-  border: 1px solid rgba(129, 140, 248, 0.2);
+  border: 0.0625rem solid rgba(129, 140, 248, 0.2);
   color: #e2e8f0;
 }
 
 body.theme-dark .shuwa-item:hover {
   background: rgba(45, 55, 72, 0.9);
   border-color: rgba(129, 140, 248, 0.4);
-  box-shadow: 0 8px 25px rgba(129, 140, 248, 0.2);
+  box-shadow: 0 0.5rem 1.5625rem rgba(129, 140, 248, 0.2);
 }
 
 body.theme-dark .shuwa-item-name {
@@ -334,11 +359,11 @@ body.theme-dark .shuwa-item-name {
 
 body.theme-dark .shuwa-items button {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 0.125rem 0.5rem rgba(102, 126, 234, 0.4);
 }
 
 body.theme-dark .shuwa-items button:hover {
-  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.5);
+  box-shadow: 0 0.25rem 0.9375rem rgba(102, 126, 234, 0.5);
 }
 
 body.theme-dark .shuwa-items h1 {
@@ -350,7 +375,7 @@ body.theme-dark .shuwa-items h1 {
 
 body.theme-dark .shuwa-items > div:not(.shuwa-item) {
   background: rgba(45, 55, 72, 0.9);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0.375rem 1.25rem rgba(0, 0, 0, 0.4);
   color: #e2e8f0;
 }
 
@@ -373,13 +398,13 @@ body.theme-minimal {
 
 body.theme-minimal .shuwa-item {
   background: #ffffff;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 0.0625rem solid #e5e7eb;
+  box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-item:hover {
   border-color: #d1d5db;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-item-name {
@@ -390,12 +415,12 @@ body.theme-minimal .shuwa-item-name {
 
 body.theme-minimal .shuwa-items button {
   background: #3b82f6;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-items button:hover {
   background: #2563eb;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
 }
 
 body.theme-minimal .shuwa-items h1 {
@@ -406,8 +431,8 @@ body.theme-minimal .shuwa-items h1 {
 
 body.theme-minimal .shuwa-items > div:not(.shuwa-item) {
   background: #ffffff;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 0.0625rem solid #e5e7eb;
+  box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.1);
 }
 
 body.theme-minimal .shuwa-items p {
@@ -430,15 +455,15 @@ body.theme-minimal .shuwa-items a:hover {
 .shuwa-items.layout-list:has(.shuwa-item) {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-top: 20px;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .shuwa-items.layout-list .shuwa-item {
   display: flex;
   align-items: center;
-  padding: 16px 20px;
-  min-height: 60px;
+  padding: 1rem 1.25rem;
+  min-height: 3.75rem;
 }
 
 .shuwa-items.layout-list .shuwa-item a {
@@ -450,55 +475,55 @@ body.theme-minimal .shuwa-items a:hover {
 .shuwa-items.layout-list .shuwa-item-name {
   margin: 0;
   padding: 0;
-  font-size: 16px;
+  font-size: 1rem;
   text-align: left;
 }
 
 /* Compact Grid Layout */
 .shuwa-items.layout-compact:has(.shuwa-item) {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 12px;
-  margin-top: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(12.5rem, 1fr));
+  gap: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .shuwa-items.layout-compact .shuwa-item {
-  padding: 12px 16px;
+  padding: 0.75rem 1rem;
 }
 
 .shuwa-items.layout-compact .shuwa-item-name {
-  font-size: 14px;
-  padding: 8px 0;
+  font-size: 0.875rem;
+  padding: 0.5rem 0;
 }
 
 /* Wide Cards Layout */
 .shuwa-items.layout-wide:has(.shuwa-item) {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  gap: 24px;
-  margin-top: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.25rem;
 }
 
 .shuwa-items.layout-wide .shuwa-item {
-  padding: 24px;
+  padding: 1.5rem;
 }
 
 .shuwa-items.layout-wide .shuwa-item-name {
-  font-size: 20px;
-  padding: 16px 0;
+  font-size: 1.25rem;
+  padding: 1rem 0;
 }
 
 /* Table View Layout */
 .shuwa-items.layout-table {
-  margin-top: 20px;
+  margin-top: 1.25rem;
 }
 
 .shuwa-items.layout-table .shuwa-table {
   width: 100%;
   background: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 0.75rem;
+  box-shadow: 0 0.25rem 0.9375rem rgba(0, 0, 0, 0.08);
+  border: 0.0625rem solid rgba(0, 0, 0, 0.05);
   overflow: hidden;
 }
 
@@ -509,9 +534,9 @@ body.theme-minimal .shuwa-items a:hover {
 
 .shuwa-items.layout-table .shuwa-table th,
 .shuwa-items.layout-table .shuwa-table td {
-  padding: 12px 16px;
+  padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 0.0625rem solid rgba(0, 0, 0, 0.05);
 }
 
 .shuwa-items.layout-table .shuwa-table th {
@@ -535,56 +560,56 @@ body.theme-minimal .shuwa-items a:hover {
 }
 
 /* Responsive adjustments for layouts */
-@media (max-width: 768px) {
+@media (max-width: 48rem) {
   .shuwa-items.layout-compact:has(.shuwa-item) {
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+    gap: 0.625rem;
   }
 
   .shuwa-items.layout-wide:has(.shuwa-item) {
     grid-template-columns: 1fr;
-    gap: 16px;
+    gap: 1rem;
   }
 
   .shuwa-items.layout-wide .shuwa-item {
-    padding: 16px;
+    padding: 1rem;
   }
 
   .shuwa-items.layout-table .shuwa-table {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 
   .shuwa-items.layout-table .shuwa-table th,
   .shuwa-items.layout-table .shuwa-table td {
-    padding: 8px 12px;
+    padding: 0.5rem 0.75rem;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 30rem) {
   .shuwa-items.layout-list .shuwa-item {
-    padding: 12px 16px;
-    min-height: 50px;
+    padding: 0.75rem 1rem;
+    min-height: 3.125rem;
   }
 
   .shuwa-items.layout-compact:has(.shuwa-item) {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(8.75rem, 1fr));
   }
 
   .shuwa-items.layout-compact .shuwa-item {
-    padding: 10px 12px;
+    padding: 0.625rem 0.75rem;
   }
 
   .shuwa-items.layout-compact .shuwa-item-name {
-    font-size: 13px;
+    font-size: 0.8125rem;
   }
 }
 
 :root {
   --frame-color: #8b4f24; /* 額縁の濃い茶色 */
-  --frame-thickness: 20px; /* 額縁の太さ（左右上下） */
-  --mat-thickness: 12px; /* 内側マットの幅（額縁とコンテンツの間） */
-  --radius: 14px; /* 角丸（必要なら調整） */
-  --outer-shadow: 18px; /* 外側の影の大きさ */
+  --frame-thickness: 1.25rem; /* 額縁の太さ（左右上下） */
+  --mat-thickness: 0.75rem; /* 内側マットの幅（額縁とコンテンツの間） */
+  --radius: 0.875rem; /* 角丸（必要なら調整） */
+  --outer-shadow: 1.125rem; /* 外側の影の大きさ */
 }
 
 /* 基本リセット（必要に応じて） */
@@ -607,19 +632,28 @@ body {
 /* グリッドコンテナ */
 .shuwa-content {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
-  margin-top: 20px;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 4rem;
+  margin-top: 2rem;
   align-items: stretch; /* 高さを揃える */
+  min-height: 30rem;
+}
+
+/* 超ワイド画面での最適化 */
+@media (min-width: 120rem) {
+  .shuwa-content {
+    grid-template-columns: 1fr 1.5fr;
+    gap: 5rem;
+  }
 }
 
 /* 動画部分 */
 .shuwa-video {
   background: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  padding: 1vh; /* 動画の周りに1vhの余白 */
+  border-radius: 1rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.12);
+  border: 0.0625rem solid rgba(0, 0, 0, 0.05);
+  padding: 2vh; /* 動画の周りに2vhの余白 */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -640,31 +674,32 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: 8px;
+  border-radius: 0.5rem;
 }
 
 /* テキスト部分 */
 .shuwa-text {
   background: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  padding: 16px;
+  border-radius: 1rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.12);
+  border: 0.0625rem solid rgba(0, 0, 0, 0.05);
+  padding: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 1.5rem;
   justify-content: center;
 }
 
 /* テキスト要素のサイズ調整 */
 .shuwa-how-to,
 .shuwa-example-sentence {
-  font-size: 2vh;
-  line-height: 1.5;
+  font-size: clamp(1.125rem, 3vh, 1.5rem);
+  line-height: 1.6;
   margin: 0;
-  padding: 10px 14px;
-  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
   position: relative;
+  font-weight: 500;
 }
 
 .shuwa-how-to {
@@ -688,13 +723,27 @@ body {
 }
 
 /* レスポンシブ対応 */
-@media (max-width: 768px) {
+@media (max-width: 48rem) {
   .shuwa-content {
     grid-template-columns: 1fr; /* モバイルでは縦並びに */
-    gap: 16px;
+    gap: 1.5rem;
+    min-height: auto;
   }
 
   .shuwa-video {
     padding: 1vh;
+  }
+
+  .shuwa-items > div:not(.shuwa-item) {
+    padding: 1.5rem;
+  }
+
+  .shuwa-items h1 {
+    font-size: 2rem;
+  }
+
+  .shuwa-text {
+    padding: 1.5rem;
+    gap: 1rem;
   }
 }

--- a/src/pages/modeselect/styles/modeselect.css
+++ b/src/pages/modeselect/styles/modeselect.css
@@ -20,32 +20,144 @@
 
 /* フォームセクション間のマージン調整 */
 .form-container + .form-container {
-  margin-top: 24px;
+  margin-top: 1.5rem;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* ワイド画面での最適化 */
+@media (min-width: 75rem) {
   .radio-option {
-    padding: 14px;
+    padding: 1.25rem 1.5rem;
+    font-size: 1.125rem;
+  }
+  
+  .radio-option label {
+    font-size: 1.125rem;
+  }
+  
+  .radio-option input[type="radio"] {
+    width: 1.375rem;
+    height: 1.375rem;
+    margin-right: 1rem;
+  }
+  
+  .form-container + .form-container {
+    margin-top: 2rem;
+  }
+}
+
+/* 標準画面での最適化 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .radio-option {
+    padding: 1rem 1.25rem;
+  }
+  
+  .radio-option label {
+    font-size: 1rem;
+  }
+  
+  .radio-option input[type="radio"] {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.875rem;
+  }
+}
+
+/* タブレット対応 */
+@media (max-width: 48rem) {
+  .radio-option {
+    padding: 0.875rem 1rem;
   }
 
   .radio-option label {
-    font-size: 18px;
+    font-size: 1.125rem;
+  }
+  
+  .radio-option input[type="radio"] {
+    width: 1.125rem;
+    height: 1.125rem;
+    margin-right: 0.75rem;
   }
 }
 
-@media (max-width: 480px) {
+/* モバイル対応 */
+@media (max-width: 30rem) {
   .radio-option {
-    padding: 12px;
+    padding: 0.75rem 0.875rem;
   }
 
   .radio-option label {
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   .radio-option input[type="radio"] {
-    width: 18px;
-    height: 18px;
-    margin-right: 10px;
+    width: 1.125rem;
+    height: 1.125rem;
+    margin-right: 0.625rem;
+  }
+}
+
+/* アニメーション強化 */
+.radio-option {
+  transition: all 0.3s ease;
+}
+
+.radio-option:hover {
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.1);
+}
+
+/* グリッドレイアウトの改善（複数選択肢がある場合） */
+.radio-group {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+/* 超ワイド画面では3列表示 */
+@media (min-width: 120rem) {
+  .radio-group {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    max-width: 80rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* ワイド画面では2列表示 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .radio-group {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    max-width: 65rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* 標準画面では1列表示 */
+@media (max-width: 74.99rem) {
+  .radio-group {
+    grid-template-columns: 1fr;
+    max-width: 50rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* フォーカス状態の改善 */
+.radio-option input[type="radio"]:focus + label {
+  box-shadow: 0 0 0 0.125rem rgba(76, 175, 80, 0.3);
+  outline: none;
+}
+
+/* アクセシビリティ向上 */
+@media (prefers-reduced-motion: reduce) {
+  .radio-option:hover {
+    transform: none;
+  }
+  
+  .radio-option {
+    transition: none;
   }
 }

--- a/src/pages/quiz/styles/quiz.css
+++ b/src/pages/quiz/styles/quiz.css
@@ -15,121 +15,267 @@
 
 .modal-content {
   background: rgba(255, 255, 255, 0.95);
-  padding: 10px;
-  border-radius: 16px;
+  padding: 1.75rem;
+  border-radius: 1rem;
   color: #1b3e26;
   text-align: center;
-  box-shadow: 0 8px 30px rgba(76, 175, 80, 0.2);
-  border: 1px solid rgba(76, 175, 80, 0.1);
-  max-width: 950px;
-  width: 95%;
-  max-height: 90vh;
+  box-shadow: 0 0.5rem 1.875rem rgba(76, 175, 80, 0.2);
+  border: 0.0625rem solid rgba(76, 175, 80, 0.1);
+  max-width: 85%;
+  width: 100%;
+  max-height: 85vh;
   overflow-y: auto;
   position: relative;
 }
 
+/* 超ワイド画面での最適化 */
+@media (min-width: 120rem) {
+  .modal-content {
+    max-width: 80%;
+    padding: 3rem;
+  }
+}
+
+/* ワイド画面での最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .modal-content {
+    max-width: 75%;
+    padding: 2.5rem;
+  }
+}
+
+/* 標準画面での最適化 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .modal-content {
+    max-width: 80%;
+    padding: 2rem;
+  }
+}
+
 .video-comparison {
-  display: flex;
-  gap: 30px;
-  margin: 20px 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  margin: 2rem 0;
   justify-content: center;
-  flex-wrap: wrap;
   align-items: flex-start;
 }
 
+/* 超ワイド画面では余裕をもった表示 */
+@media (min-width: 120rem) {
+  .video-comparison {
+    gap: 3rem;
+    margin: 2.5rem 0;
+  }
+}
+
+/* ワイド画面では余裕をもった表示 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .video-comparison {
+    gap: 2.5rem;
+    margin: 2rem 0;
+  }
+}
+
 .video-comparison > div {
-  flex: 1;
-  min-width: 350px;
-  max-width: 450px;
   text-align: center;
   position: relative;
   z-index: 1;
-  clear: both;
   overflow: hidden;
+  min-height: 15rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .video-comparison video,
 .video-comparison iframe {
-  /*width: 100%;*/
-  /*max-width: 400px;
-  height: 225px; /* 400px * 9/16 = 225px for 16:9 ratio */
-  border: 2px solid rgba(76, 175, 80, 0.2);
-  border-radius: 8px;
+  border: 0.125rem solid rgba(76, 175, 80, 0.2);
+  border-radius: 0.75rem;
   display: block;
-  /*margin: 0 auto;*/
+  width: 100%;
+  height: auto;
   position: relative;
   z-index: 1;
-  clear: both;
   aspect-ratio: 16/9;
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.1);
 }
 
 .video-comparison p {
-  margin-bottom: 12px;
+  margin-bottom: 1rem;
   font-weight: 600;
   color: #2e7d32;
+  font-size: 1.125rem;
 }
 
 .choice-buttons {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 15px;
-  margin: 20px 0;
+  gap: 1.25rem;
+  margin: 2rem 0;
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* 超ワイド画面では4列表示 */
+@media (min-width: 120rem) {
+  .choice-buttons {
+    grid-template-columns: repeat(4, 1fr);
+    max-width: 60rem;
+    gap: 1.5rem;
+  }
+}
+
+/* ワイド画面では余裕をもった2列表示 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .choice-buttons {
+    max-width: 50rem;
+    gap: 1.5rem;
+  }
 }
 
 .choice-btn {
-  padding: 12px 20px;
+  padding: 1rem 1.5rem;
   background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
   color: #0d47a1;
-  border: 2px solid rgba(76, 175, 80, 0.3);
-  border-radius: 8px;
-  font-size: 16px;
+  border: 0.125rem solid rgba(76, 175, 80, 0.3);
+  border-radius: 0.75rem;
+  font-size: 1rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.3s ease;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .choice-btn:hover {
   background: linear-gradient(135deg, #4caf50 0%, #66bb6a 100%);
   color: white;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.3);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.3);
 }
 
 #video-container {
   background: white;
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.1);
-  margin-bottom: 20px;
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 0.5rem 1.25rem rgba(76, 175, 80, 0.12);
+  margin-bottom: 2.5rem;
   text-align: center;
+  max-width: 98%;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* 動画コンテナ内のiframe最適化 */
+#video-container iframe {
+  width: 100%;
+  min-height: 25rem;
+  aspect-ratio: 16/9;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.1);
+}
+
+/* ワイド画面での動画iframe最適化 */
+@media (min-width: 75rem) {
+  #video-container iframe {
+    min-height: 30rem;
+  }
+}
+
+/* 超ワイド画面での動画iframe最適化 */
+@media (min-width: 120rem) {
+  #video-container iframe {
+    min-height: 35rem;
+  }
+}
+
+/* 超ワイド画面での動画コンテナ最適化 */
+@media (min-width: 120rem) {
+  #video-container {
+    max-width: 90%;
+    padding: 4rem;
+  }
+}
+
+/* ワイド画面での動画コンテナ最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  #video-container {
+    max-width: 85%;
+    padding: 3.5rem;
+  }
+}
+
+/* タブレット対応 */
+@media (max-width: 48rem) {
   .video-comparison {
-    flex-direction: column;
-    gap: 20px;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .modal-content {
+    padding: 1.5rem;
+    width: 95%;
   }
 
   .choice-buttons {
     grid-template-columns: 1fr;
-    gap: 12px;
+    gap: 1rem;
+    max-width: none;
   }
 
   .choice-btn {
-    padding: 14px 20px;
-    font-size: 16px;
+    padding: 1rem 1.25rem;
+    font-size: 1rem;
+  }
+  
+  #video-container {
+    padding: 2rem;
+    margin-bottom: 2rem;
+    max-width: 95%;
   }
 }
 
-@media (max-width: 480px) {
+/* 小画面モバイル対応 */
+@media (max-width: 30rem) {
   .modal-content {
-    padding: 20px;
+    padding: 1.25rem;
     width: 98%;
   }
 
   .choice-btn {
-    padding: 12px 16px;
-    font-size: 14px;
+    padding: 0.875rem 1rem;
+    font-size: 0.9rem;
+    min-height: 2.5rem;
+  }
+  
+  .video-comparison p {
+    font-size: 1rem;
+  }
+  
+  #video-container {
+    padding: 1.25rem;
+  }
+}
+
+/* アニメーション強化 */
+.choice-btn:active {
+  transform: translateY(0);
+}
+
+.video-comparison > div:hover {
+  transform: translateY(-0.125rem);
+  transition: transform 0.3s ease;
+}
+
+/* アクセシビリティ向上 */
+@media (prefers-reduced-motion: reduce) {
+  .choice-btn:hover,
+  .video-comparison > div:hover {
+    transform: none;
   }
 }

--- a/src/pages/result/scripts/show-result.ts
+++ b/src/pages/result/scripts/show-result.ts
@@ -1,6 +1,7 @@
 import { createShuwaDetailHTML } from "../../../components/shuwa-detail/shuwa-detail";
 import type { ShuwaData } from "../../../types";
 import data from "../../../../data/shuwa.json";
+import { QUIZ_COUNT_KEY } from "../../../constants/localStorage";
 
 const shuwaData: ShuwaData[] = data as ShuwaData[];
 
@@ -22,6 +23,14 @@ function resultItems(): string {
     result,
   }));
 
+  let quizCount = parseInt(localStorage.getItem(QUIZ_COUNT_KEY) || "0", 10);
+
+  for (const i of quizData) {
+    if (i.result) {
+      quizCount++;
+    }
+  }
+  localStorage.setItem(QUIZ_COUNT_KEY, quizCount.toString());
   console.log(quizData);
 
   return `

--- a/src/pages/result/styles/result.css
+++ b/src/pages/result/styles/result.css
@@ -19,11 +19,35 @@
 .shuwa-modal .shuwa-detail {
   background-color: #fff;
   padding: 2rem;
-  border-radius: 16px;
-  max-width: 800px;
-  width: 90%;
+  border-radius: 1rem;
+  max-width: 95%;
+  width: 100%;
   position: relative;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0.625rem 1.875rem rgba(0, 0, 0, 0.3);
+}
+
+/* 超ワイド画面での最適化 */
+@media (min-width: 120rem) {
+  .shuwa-modal .shuwa-detail {
+    max-width: 95%;
+    padding: 4rem;
+  }
+}
+
+/* ワイド画面での最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .shuwa-modal .shuwa-detail {
+    max-width: 90%;
+    padding: 3.5rem;
+  }
+}
+
+/* 標準画面での最適化 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .shuwa-modal .shuwa-detail {
+    max-width: 95%;
+    padding: 2.5rem;
+  }
 }
 
 .modal-close-button {
@@ -37,8 +61,8 @@
   border: none;
   background: transparent;
   z-index: 1001;
-  width: 40px;
-  height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,146 +78,235 @@
 /* 結果コンテナのスタイル */
 .result-container {
   text-align: center;
-  padding: 20px 0;
-  margin-bottom: 30px;
+  padding: 1.25rem 0;
+  margin-bottom: 1.875rem;
+}
+
+/* ワイド画面での結果コンテナ最適化 */
+@media (min-width: 75rem) {
+  .result-container {
+    padding: 2rem 0;
+    margin-bottom: 2.5rem;
+  }
 }
 
 /* 結果表示の基本レイアウト */
 .result-content {
   background: rgba(255, 255, 255, 0.98);
-  border-radius: 16px;
-  padding: 30px;
-  margin: 20px 0;
-  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.1);
-  border: 1px solid rgba(76, 175, 80, 0.15);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin: 1.25rem 0;
+  box-shadow: 0 0.375rem 1.25rem rgba(76, 175, 80, 0.1);
+  border: 0.0625rem solid rgba(76, 175, 80, 0.15);
   transition: all 0.3s ease;
+}
+
+/* 超ワイド画面での結果コンテンツ最適化 */
+@media (min-width: 120rem) {
+  .result-content {
+    padding: 3.5rem;
+    margin: 3rem 0;
+    max-width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* ワイド画面での結果コンテンツ最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .result-content {
+    padding: 3rem;
+    margin: 2.5rem 0;
+    max-width: 85%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 /* 結果のメインメッセージ */
 .result-message {
-  font-size: 32px;
+  font-size: 2rem;
   font-weight: 800;
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
   background: linear-gradient(135deg, #2e7d32 0%, #4caf50 100%);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
+/* ワイド画面でのメッセージ最適化 */
+@media (min-width: 75rem) {
+  .result-message {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+  }
+}
+
 /* 正答率表示 */
 .accuracy-display {
-  font-size: 48px;
+  font-size: 3rem;
   font-weight: 900;
   color: #2e7d32;
-  margin: 20px 0;
-  text-shadow: 2px 2px 4px rgba(76, 175, 80, 0.2);
+  margin: 1.25rem 0;
+  text-shadow: 0.125rem 0.125rem 0.25rem rgba(76, 175, 80, 0.2);
+}
+
+/* ワイド画面での正答率表示最適化 */
+@media (min-width: 75rem) {
+  .accuracy-display {
+    font-size: 3.5rem;
+    margin: 2rem 0;
+  }
 }
 
 /* 結果統計のスタイル */
 .result-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 20px;
-  margin: 30px 0;
+  grid-template-columns: repeat(auto-fit, minmax(8.75rem, 1fr));
+  gap: 1.25rem;
+  margin: 1.875rem 0;
+}
+
+/* 超ワイド画面での統計表示最適化 */
+@media (min-width: 120rem) {
+  .result-stats {
+    grid-template-columns: repeat(5, 1fr);
+    gap: 3rem;
+    margin: 3rem 0;
+    max-width: 90rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* ワイド画面での統計表示最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .result-stats {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2.5rem;
+    margin: 2.5rem 0;
+    max-width: 75rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/* 標準画面での統計表示 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .result-stats {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+    max-width: 45rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .stat-item {
   text-align: center;
-  padding: 20px;
+  padding: 1.25rem;
   background: linear-gradient(
     135deg,
     rgba(76, 175, 80, 0.05) 0%,
     rgba(76, 175, 80, 0.1) 100%
   );
-  border-radius: 12px;
-  border: 1px solid rgba(76, 175, 80, 0.15);
+  border-radius: 0.75rem;
+  border: 0.0625rem solid rgba(76, 175, 80, 0.15);
   transition: all 0.3s ease;
 }
 
 .stat-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.15);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.15);
 }
 
 .stat-value {
-  font-size: 32px;
+  font-size: 2rem;
   font-weight: 800;
   color: #2e7d32;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   display: block;
 }
 
+/* ワイド画面での統計値最適化 */
+@media (min-width: 75rem) {
+  .stat-value {
+    font-size: 2.25rem;
+  }
+}
+
 .stat-label {
-  font-size: 16px;
+  font-size: 1rem;
   color: #1b5e20;
   font-weight: 600;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* タブレット対応 */
+@media (max-width: 48rem) {
   .result-content {
-    padding: 20px;
-    margin: 15px 0;
+    padding: 1.25rem;
+    margin: 0.9375rem 0;
   }
 
   .result-message {
-    font-size: 28px;
+    font-size: 1.75rem;
   }
 
   .accuracy-display {
-    font-size: 40px;
+    font-size: 2.5rem;
   }
 
   .result-stats {
     grid-template-columns: repeat(2, 1fr);
-    gap: 15px;
-    margin: 20px 0;
+    gap: 0.9375rem;
+    margin: 1.25rem 0;
   }
 
   .stat-item {
-    padding: 16px;
+    padding: 1rem;
   }
 
   .stat-value {
-    font-size: 28px;
+    font-size: 1.75rem;
   }
 }
 
-@media (max-width: 480px) {
+/* モバイル対応 */
+@media (max-width: 30rem) {
   .result-content {
-    padding: 16px;
+    padding: 1rem;
   }
 
   .result-message {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
 
   .accuracy-display {
-    font-size: 36px;
+    font-size: 2.25rem;
   }
 
   .result-stats {
     grid-template-columns: 1fr;
-    gap: 12px;
+    gap: 0.75rem;
   }
 
   .stat-value {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
 
   .stat-label {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
 /* 問題別結果表示 */
 .result-item {
   background: rgba(255, 255, 255, 0.95);
-  border-radius: 12px;
-  padding: 20px;
-  margin: 16px 0;
-  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.1);
-  border: 1px solid rgba(76, 175, 80, 0.1);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  margin: 1rem 0;
+  box-shadow: 0 0.25rem 0.9375rem rgba(76, 175, 80, 0.1);
+  border: 0.0625rem solid rgba(76, 175, 80, 0.1);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -201,12 +314,12 @@
 }
 
 .result-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.15);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.375rem 1.25rem rgba(76, 175, 80, 0.15);
 }
 
 .result-item h2 {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 600;
   color: #2e7d32;
   margin: 0;
@@ -214,50 +327,42 @@
 }
 
 .result-item p {
-  font-size: 32px;
+  font-size: 2rem;
   font-weight: 800;
-  margin: 0 20px;
-  width: 40px;
+  margin: 0 1.25rem;
+  width: 2.5rem;
   text-align: center;
-}
-
-.result-item p:contains("○") {
-  color: #4caf50;
-}
-
-.result-item p:contains("×") {
-  color: #f44336;
 }
 
 /* 正解・不正解の色分け */
 .result-correct {
   color: #4caf50 !important;
-  text-shadow: 2px 2px 4px rgba(76, 175, 80, 0.2);
+  text-shadow: 0.125rem 0.125rem 0.25rem rgba(76, 175, 80, 0.2);
 }
 
 .result-incorrect {
   color: #f44336 !important;
-  text-shadow: 2px 2px 4px rgba(244, 67, 54, 0.2);
+  text-shadow: 0.125rem 0.125rem 0.25rem rgba(244, 67, 54, 0.2);
 }
 
 /* 解説ボタン */
 .explanation-button {
-  padding: 10px 20px;
+  padding: 0.625rem 1.25rem;
   background: linear-gradient(135deg, #2196f3 0%, #1976d2 100%);
   color: white;
   border: none;
-  border-radius: 8px;
-  font-size: 14px;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 3px 10px rgba(33, 150, 243, 0.3);
-  min-width: 80px;
+  box-shadow: 0 0.1875rem 0.625rem rgba(33, 150, 243, 0.3);
+  min-width: 5rem;
 }
 
 .explanation-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(33, 150, 243, 0.4);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.3125rem 0.9375rem rgba(33, 150, 243, 0.4);
   background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
 }
 
@@ -267,68 +372,78 @@
 
 /* 戻るボタン（動的生成される） */
 #quiz-back {
-  margin-top: 30px;
-  padding: 16px 32px;
+  margin-top: 1.875rem;
+  padding: 1rem 2rem;
   background: linear-gradient(135deg, #e0e0e0 0%, #bdbdbd 100%);
   color: #424242;
   border: none;
-  border-radius: 12px;
-  font-size: 16px;
+  border-radius: 0.75rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.25rem 0.9375rem rgba(0, 0, 0, 0.1);
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
 
 #quiz-back:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.375rem 1.25rem rgba(0, 0, 0, 0.15);
   background: linear-gradient(135deg, #d0d0d0 0%, #a0a0a0 100%);
 }
 
 /* レスポンシブ対応 - 問題別結果 */
-@media (max-width: 768px) {
+@media (max-width: 48rem) {
   .result-item {
-    padding: 16px;
+    padding: 1rem;
     flex-direction: column;
     text-align: center;
-    gap: 12px;
+    gap: 0.75rem;
   }
 
   .result-item h2 {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 
   .result-item p {
-    font-size: 28px;
+    font-size: 1.75rem;
     margin: 0;
   }
 
   .explanation-button {
     width: 100%;
-    padding: 12px;
+    padding: 0.75rem;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 30rem) {
   .result-item {
-    padding: 12px;
-    margin: 12px 0;
+    padding: 0.75rem;
+    margin: 0.75rem 0;
   }
 
   .result-item h2 {
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   .result-item p {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
 
   .explanation-button {
-    font-size: 12px;
-    padding: 10px;
+    font-size: 0.75rem;
+    padding: 0.625rem;
+  }
+}
+
+/* アクセシビリティ向上 */
+@media (prefers-reduced-motion: reduce) {
+  .stat-item:hover,
+  .result-item:hover,
+  .explanation-button:hover,
+  #quiz-back:hover {
+    transform: none;
   }
 }

--- a/src/pages/styles/style.css
+++ b/src/pages/styles/style.css
@@ -1,9 +1,9 @@
 :root {
   --frame-color: #8b4f24; /* 額縁の濃い茶色 */
-  --frame-thickness: 20px; /* 額縁の太さ（左右上下） */
-  --mat-thickness: 12px; /* 内側マットの幅（額縁とコンテンツの間） */
-  --radius: 14px; /* 角丸（必要なら調整） */
-  --outer-shadow: 18px; /* 外側の影の大きさ */
+  --frame-thickness: 1.25rem; /* 額縁の太さ（左右上下） */
+  --mat-thickness: 0.75rem; /* 内側マットの幅（額縁とコンテンツの間） */
+  --radius: 0.875rem; /* 角丸（必要なら調整） */
+  --outer-shadow: 1.125rem; /* 外側の影の大きさ */
 }
 /* 固定オーバーレイ（フレーム本体） */
 .screen-frame {
@@ -48,9 +48,9 @@
   z-index: 20; /* screen-frame より大きくすることで枠の上にコンテンツを出す */
   min-height: 100vh; /* 最小高さをビューポートに設定し、コンテンツに応じて拡張 */
   background: #28a44a;
-  padding-left: 56px;
-  padding-right: 56px;
-  padding-top: 10px;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  padding-top: 0.625rem;
   color: #1b3e26;
   font-family:
     system-ui,
@@ -72,19 +72,43 @@
 /* 基本カードスタイル */
 .page-card {
   background: rgba(255, 255, 255, 0.95);
-  border-radius: 16px;
-  padding: 30px;
-  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.1);
-  border: 1px solid rgba(76, 175, 80, 0.1);
-  margin: 20px 0;
-  max-width: 800px;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 0.375rem 1.25rem rgba(76, 175, 80, 0.1);
+  border: 0.0625rem solid rgba(76, 175, 80, 0.1);
+  margin: 1.25rem 0;
+  max-width: 98%;
   width: 100%;
   transition: all 0.3s ease;
 }
 
+/* 超ワイド画面での最適化 */
+@media (min-width: 120rem) {
+  .page-card {
+    max-width: 95%;
+    padding: 3.5rem;
+  }
+}
+
+/* ワイド画面での最適化 */
+@media (min-width: 75rem) and (max-width: 119.99rem) {
+  .page-card {
+    max-width: 92%;
+    padding: 3rem;
+  }
+}
+
+/* 標準画面での最適化 */
+@media (max-width: 74.99rem) and (min-width: 48.01rem) {
+  .page-card {
+    max-width: 95%;
+    padding: 2.5rem;
+  }
+}
+
 .page-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.15);
+  transform: translateY(-0.125rem);
+  box-shadow: 0 0.5rem 1.5625rem rgba(76, 175, 80, 0.15);
   border-color: rgba(76, 175, 80, 0.2);
 }
 


### PR DESCRIPTION
## Summary

- 単語詳細ページ閲覧によるアチーブメント解除システムを実装
- 学習した数によるアチーブ条件解除機能を追加
- CSSのpx単位を相対単位（rem/em/vh/vw）に統一
- LocalStorageを活用した学習進捗管理システムを構築

### 主な変更点

#### アチーブメント機能
- 単語詳細ページ閲覧時の自動アチーブ解除
- 学習した単語数に基づくアチーブ条件の追加
- LocalStorageでの学習データ永続化

#### UI/UX改善  
- 共通コンポーネント（ShuwaDetail）の活用
- レスポンシブデザインの向上
- アクセシビリティ対応（相対単位使用）

#### 技術的改善
- CSS設計原則に従った相対単位への統一
- 型安全性の向上
- コンポーネント化による保守性向上

## Test plan

- [x] アチーブメント解除の動作確認
- [x] 学習データ保存の確認
- [ ] レスポンシブデザインの表示確認
- [ ] 異なるデバイス・ブラウザでの動作確認

## 関連Issue
#19 