### PR TITLE
fix: 実績バッジに指文字画像を表示し中央配置に修正

### DIFF
--- a/src/pages/achieve/scripts/show-achieve.ts
+++ b/src/pages/achieve/scripts/show-achieve.ts
@@ -283,12 +283,28 @@ const ACHIEVEMENT_CONDITIONS = new Map<string, AchievementCondition>([
 
 // Team member hiragana characters
 const MEMBER_CHARACTERS = {
-  imamura: ["い", "ま", "む", "ら", "あ", "こ"],
-  uchimura: ["う", "ち", "む", "ら", "と", "も", "き"],
-  itoga: ["い", "と", "が", "た", "い", "よ", "う"],
-  fukuda: ["ふ", "く", "だ", "け", "い", "と"],
-  kagimoto: ["か", "ぎ", "も", "と", "え", "い", "じ"],
-  reader: ["お", "お", "か", "わ", "せ", "い", "や"],
+  imamura: ["i.png", "ma.png", "mu.png", "ra.png", "a.png", "ko.png"],
+  uchimura: [
+    "u.png",
+    "chi.png",
+    "mu.png",
+    "ra.png",
+    "to.png",
+    "mo.png",
+    "ki.png",
+  ],
+  itoga: ["i.png", "to.png", "ga.gif", "ta.png", "i.png", "yo.png", "u.png"],
+  fukuda: ["fu.png", "ku.png", "da.png", "ke.png", "i.png", "to.png"],
+  kagimoto: [
+    "ka.png",
+    "gi.gif",
+    "mo.png",
+    "to.png",
+    "e.png",
+    "i.png",
+    "ji.gif",
+  ],
+  reader: ["o.png", "o.png", "ka.png", "wa.png", "se.png", "i.png", "ya.png"],
 };
 
 // Achievement badge selectors
@@ -393,7 +409,8 @@ function updateAchievementUI(): void {
           }
 
           element.classList.add("completed");
-          element.textContent = hiraganaChar;
+          const charName = hiraganaChar.replace(".png", "");
+          element.innerHTML = `<img src="/new/${hiraganaChar}" alt="${charName}" width="28" height="28">`;
         } else {
           element.classList.remove("completed");
           element.textContent = "？";

--- a/src/pages/achieve/styles/style.css
+++ b/src/pages/achieve/styles/style.css
@@ -74,7 +74,9 @@ header h1 {
 .reader span:not(.reader-click),
 .kagimoto span,
 .fukuda span {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 42px;
   height: 42px;
   background: #bdc3c7;
@@ -99,6 +101,18 @@ header h1 {
   color: white;
   box-shadow: 0 3px 8px rgba(46, 204, 113, 0.3);
   transform: scale(1.05);
+}
+
+.itoga span img,
+.imamura span img,
+.uchimura span img,
+.reader span img,
+.kagimoto span img,
+.fukuda span img {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .reader-click {
@@ -164,6 +178,16 @@ header h1 {
     line-height: 38px;
     font-size: 0.9rem;
     margin: 3px 4px;
+  }
+
+  .itoga span img,
+  .imamura span img,
+  .uchimura span img,
+  .reader span img,
+  .kagimoto span img,
+  .fukuda span img {
+    width: 24px;
+    height: 24px;
   }
 
   .itoga,


### PR DESCRIPTION
- ひらがな文字から指文字画像への表示変更 - textContentからinnerHTMLへの変更で画像タグを正しくレンダリング - 画像 パスに/new/を追加し正しい画像を参照 - flexboxで画像を円形背景の中央に配置 - レスポンシブ対応で画像サイズを調整

# プルリクエスト
This pull request updates the achievement UI for team members by switching from displaying hiragana characters to showing corresponding character images. The changes enhance the visual experience and ensure proper styling and layout for the new image-based badges.

**UI and Data Representation Updates:**

* Replaced hiragana character strings in the `MEMBER_CHARACTERS` object with image filenames (e.g., `i.png`, `ma.png`, `ga.gif`), so achievements now reference images instead of text.
* Updated the achievement rendering logic in `updateAchievementUI` to display images for completed achievements by inserting an `<img>` tag, instead of setting text content.

**Styling and Layout Adjustments:**

* Changed the display property for achievement badge containers from `inline-block` to `inline-flex` and centered content to better accommodate images.
* Added CSS rules to ensure images inside achievement badges scale properly, do not overflow, and maintain aspect ratio.
* Added responsive styles for images within badges on small screens, setting their width and height to `24px` for consistency.

**なんかよくわかんないけど、英語で書かれてます**